### PR TITLE
[FEATURE] 강의 API 구분

### DIFF
--- a/src/main/java/com/example/backend/lecture/controller/LectureController.java
+++ b/src/main/java/com/example/backend/lecture/controller/LectureController.java
@@ -1,6 +1,8 @@
 package com.example.backend.lecture.controller;
 
 import com.example.backend.lecture.entity.dto.request.CreateLectureRequestDTO;
+import com.example.backend.lecture.entity.dto.request.CreateOneDayLectureRequestDTO;
+import com.example.backend.lecture.entity.dto.request.CreateRegularLectureRequestDTO;
 import com.example.backend.lecture.entity.dto.response.LectureDetailResponseDTO;
 import com.example.backend.lecture.entity.dto.response.LectureListResponseDTO;
 import com.example.backend.lecture.service.LectureService;
@@ -20,12 +22,20 @@ import java.util.List;
 public class LectureController {
     private final LectureService lectureService;
 
-    @PostMapping(value = "/create", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<LectureDetailResponseDTO> createLecture(@RequestPart("lecture") @Valid CreateLectureRequestDTO req,
+    @PostMapping(value = "/create/oneday", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<LectureDetailResponseDTO> createOneDayLecture(@RequestPart("lecture") @Valid CreateOneDayLectureRequestDTO req,
                                                                   @RequestPart("images") List<MultipartFile> images,
                                                                   Authentication auth){
         String email = auth.getName();
-        return ResponseEntity.ok(lectureService.createLecture(req, email, images));
+        return ResponseEntity.ok(lectureService.createOneDayLecture(req, email, images));
+    }
+
+    @PostMapping(value = "/create/regular", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<LectureDetailResponseDTO> createRegularLecture(@RequestPart("lecture") @Valid CreateRegularLectureRequestDTO req,
+                                                                  @RequestPart("images") List<MultipartFile> images,
+                                                                  Authentication auth){
+        String email = auth.getName();
+        return ResponseEntity.ok(lectureService.createRegularLecture(req, email, images));
     }
 
     @GetMapping("/own")

--- a/src/main/java/com/example/backend/lecture/converter/LectureConverter.java
+++ b/src/main/java/com/example/backend/lecture/converter/LectureConverter.java
@@ -3,7 +3,6 @@ package com.example.backend.lecture.converter;
 import com.example.backend.lecture.entity.Lecture;
 import com.example.backend.lecture.entity.OneDayLecture;
 import com.example.backend.lecture.entity.RegularLecture;
-import com.example.backend.lecture.entity.dto.request.CreateLectureRequestDTO;
 import com.example.backend.lecture.entity.dto.request.CreateOneDayLectureRequestDTO;
 import com.example.backend.lecture.entity.dto.request.CreateRegularLectureRequestDTO;
 import com.example.backend.lecture.entity.dto.response.LectureDetailResponseDTO;
@@ -18,11 +17,22 @@ public class LectureConverter {
                 .price(req.getPrice())
                 .member_limit(req.getMember_limit())
                 .location(req.getLocation())
-                .
+                .dateTime(req.getDateTime())
+                .build();
     }
 
     public static RegularLecture createRegularLectureConverter(CreateRegularLectureRequestDTO req){
-        return RegularLecture.builder().
+        return RegularLecture.builder()
+                .name(req.getName())
+                .description(req.getDescription())
+                .price(req.getPrice())
+                .member_limit(req.getMember_limit())
+                .location(req.getLocation())
+                .startDate(req.getStartDate())
+                .endDate(req.getEndDate())
+                .time(req.getTime())
+                .daysOfWeek(req.getDaysOfWeek())
+                .build();
     }
 
     public static LectureDetailResponseDTO lectureDetailConverter(Lecture lecture){
@@ -31,10 +41,21 @@ public class LectureConverter {
         dto.setName(lecture.getName());
         dto.setDescription(lecture.getDescription());
         dto.setPrice(lecture.getPrice());
-        dto.setType(lecture.getType());
-        dto.setMember_limit(lecture.getMember_limit());
-        dto.setDateTime(lecture.getDateTime());
         dto.setLocation(lecture.getLocation());
+        dto.setMember_limit(lecture.getMember_limit());
+        if (lecture instanceof OneDayLecture){
+            OneDayLecture oneDayLecture = (OneDayLecture) lecture;
+            dto.setType("OneDay");
+            dto.setDateTime(oneDayLecture.getDateTime());
+        } else if (lecture instanceof RegularLecture){
+            RegularLecture regularLecture = (RegularLecture) lecture;
+            dto.setType("Regular");
+            dto.setStartDate(regularLecture.getStartDate());
+            dto.setEndDate(regularLecture.getEndDate());
+            dto.setTime(regularLecture.getTime());
+            dto.setDaysOfWeek(regularLecture.getDaysOfWeek());
+        }
+
         return dto;
     }
 
@@ -42,8 +63,14 @@ public class LectureConverter {
         LectureListResponseDTO dto = new LectureListResponseDTO();
         dto.setId(lecture.getId());
         dto.setName(lecture.getName());
-        dto.setDateTime(lecture.getDateTime());
-        dto.setType(lecture.getType());
+        dto.setType(lecture instanceof OneDayLecture ? "OneDay" : "Regular");
+
+        if (lecture instanceof OneDayLecture){
+            dto.setDateTime(((OneDayLecture) lecture).getDateTime());
+        } else if (lecture instanceof RegularLecture){
+            dto.
+        }
+
         dto.setImageUrl(lecture.getLectureImages());
         return dto;
     }

--- a/src/main/java/com/example/backend/lecture/converter/LectureConverter.java
+++ b/src/main/java/com/example/backend/lecture/converter/LectureConverter.java
@@ -17,7 +17,9 @@ public class LectureConverter {
                 .price(req.getPrice())
                 .member_limit(req.getMember_limit())
                 .location(req.getLocation())
-                .dateTime(req.getDateTime())
+                .startTime()
+                .endTime()
+                .date()
                 .build();
     }
 

--- a/src/main/java/com/example/backend/lecture/converter/LectureConverter.java
+++ b/src/main/java/com/example/backend/lecture/converter/LectureConverter.java
@@ -1,22 +1,28 @@
 package com.example.backend.lecture.converter;
 
 import com.example.backend.lecture.entity.Lecture;
+import com.example.backend.lecture.entity.OneDayLecture;
+import com.example.backend.lecture.entity.RegularLecture;
 import com.example.backend.lecture.entity.dto.request.CreateLectureRequestDTO;
+import com.example.backend.lecture.entity.dto.request.CreateOneDayLectureRequestDTO;
+import com.example.backend.lecture.entity.dto.request.CreateRegularLectureRequestDTO;
 import com.example.backend.lecture.entity.dto.response.LectureDetailResponseDTO;
 import com.example.backend.lecture.entity.dto.response.LectureListResponseDTO;
 
 public class LectureConverter {
 
-    public static Lecture createLectureConverter(CreateLectureRequestDTO req){
-        return Lecture.builder()
+    public static OneDayLecture createOneDayLectureConverter(CreateOneDayLectureRequestDTO req){
+        return OneDayLecture.builder()
                 .name(req.getName())
-                .description(req.getDescription() != null ? req.getDescription() : "") // 설명이 없다면 비어있도록
+                .description(req.getDescription() != null ? req.getDescription() : "")
                 .price(req.getPrice())
-                .type(req.getType())
                 .member_limit(req.getMember_limit())
-                .dateTime(req.getDateTime())
                 .location(req.getLocation())
-                .build();
+                .
+    }
+
+    public static RegularLecture createRegularLectureConverter(CreateRegularLectureRequestDTO req){
+        return RegularLecture.builder().
     }
 
     public static LectureDetailResponseDTO lectureDetailConverter(Lecture lecture){

--- a/src/main/java/com/example/backend/lecture/converter/LectureConverter.java
+++ b/src/main/java/com/example/backend/lecture/converter/LectureConverter.java
@@ -17,9 +17,9 @@ public class LectureConverter {
                 .price(req.getPrice())
                 .member_limit(req.getMember_limit())
                 .location(req.getLocation())
-                .startTime()
-                .endTime()
-                .date()
+                .startTime(req.getStartTime())
+                .endTime(req.getEndTime())
+                .date(req.getDate())
                 .build();
     }
 
@@ -30,9 +30,10 @@ public class LectureConverter {
                 .price(req.getPrice())
                 .member_limit(req.getMember_limit())
                 .location(req.getLocation())
+                .startTime(req.getStartTime())
+                .endTime(req.getEndTime())
                 .startDate(req.getStartDate())
                 .endDate(req.getEndDate())
-                .time(req.getTime())
                 .daysOfWeek(req.getDaysOfWeek())
                 .build();
     }
@@ -45,16 +46,17 @@ public class LectureConverter {
         dto.setPrice(lecture.getPrice());
         dto.setLocation(lecture.getLocation());
         dto.setMember_limit(lecture.getMember_limit());
+        dto.setStartTime(lecture.getStartTime());
+        dto.setEndTime(lecture.getEndTime());
         if (lecture instanceof OneDayLecture){
             OneDayLecture oneDayLecture = (OneDayLecture) lecture;
             dto.setType("OneDay");
-            dto.setDateTime(oneDayLecture.getDateTime());
+            dto.setDate(oneDayLecture.getDate());
         } else if (lecture instanceof RegularLecture){
             RegularLecture regularLecture = (RegularLecture) lecture;
             dto.setType("Regular");
             dto.setStartDate(regularLecture.getStartDate());
             dto.setEndDate(regularLecture.getEndDate());
-            dto.setTime(regularLecture.getTime());
             dto.setDaysOfWeek(regularLecture.getDaysOfWeek());
         }
 
@@ -66,13 +68,7 @@ public class LectureConverter {
         dto.setId(lecture.getId());
         dto.setName(lecture.getName());
         dto.setType(lecture instanceof OneDayLecture ? "OneDay" : "Regular");
-
-        if (lecture instanceof OneDayLecture){
-            dto.setDateTime(((OneDayLecture) lecture).getDateTime());
-        } else if (lecture instanceof RegularLecture){
-            dto.
-        }
-
+        dto.setPrice(lecture.getPrice());
         dto.setImageUrl(lecture.getLectureImages());
         return dto;
     }

--- a/src/main/java/com/example/backend/lecture/entity/Lecture.java
+++ b/src/main/java/com/example/backend/lecture/entity/Lecture.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -13,7 +14,7 @@ import java.util.List;
 
 @Entity
 @Table(name = "Lecture")
-@Builder(toBuilder = true)
+@SuperBuilder(toBuilder = true)
 @DiscriminatorColumn(name = "lecture_type")
 @Getter
 @NoArgsConstructor

--- a/src/main/java/com/example/backend/lecture/entity/Lecture.java
+++ b/src/main/java/com/example/backend/lecture/entity/Lecture.java
@@ -14,6 +14,7 @@ import java.util.List;
 @Entity
 @Table(name = "Lecture")
 @Builder(toBuilder = true)
+@DiscriminatorColumn(name = "lecture_type")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -33,14 +34,8 @@ public class Lecture {
     @NotNull
     private Long price;
 
-    @NotBlank
-    private String type;
-
     @NotNull
     private int member_limit;
-
-    @NotNull
-    private Instant dateTime;
 
     @NotBlank
     private String location;

--- a/src/main/java/com/example/backend/lecture/entity/Lecture.java
+++ b/src/main/java/com/example/backend/lecture/entity/Lecture.java
@@ -9,6 +9,7 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 import java.time.Instant;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -37,6 +38,12 @@ public class Lecture {
 
     @NotNull
     private int member_limit;
+
+    @NotNull
+    private LocalTime startTime;
+
+    @NotNull
+    private LocalTime endTime;
 
     @NotBlank
     private String location;

--- a/src/main/java/com/example/backend/lecture/entity/OneDayLecture.java
+++ b/src/main/java/com/example/backend/lecture/entity/OneDayLecture.java
@@ -6,16 +6,18 @@ import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 import java.time.Instant;
 
 @Entity
 @DiscriminatorValue("OneDay")
+@SuperBuilder(toBuilder = true)
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class OneDayLecture extends Lecture{
 
     @NotNull(message = "날짜가 비어있습니다.")
-    private Instant dataTime;
+    private Instant lectureDateTime;
 }

--- a/src/main/java/com/example/backend/lecture/entity/OneDayLecture.java
+++ b/src/main/java/com/example/backend/lecture/entity/OneDayLecture.java
@@ -1,0 +1,21 @@
+package com.example.backend.lecture.entity;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Entity
+@DiscriminatorValue("OneDay")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OneDayLecture extends Lecture{
+
+    @NotNull(message = "날짜가 비어있습니다.")
+    private Instant dataTime;
+}

--- a/src/main/java/com/example/backend/lecture/entity/OneDayLecture.java
+++ b/src/main/java/com/example/backend/lecture/entity/OneDayLecture.java
@@ -19,5 +19,5 @@ import java.time.Instant;
 public class OneDayLecture extends Lecture{
 
     @NotNull(message = "날짜가 비어있습니다.")
-    private Instant lectureDateTime;
+    private Instant dateTime;
 }

--- a/src/main/java/com/example/backend/lecture/entity/OneDayLecture.java
+++ b/src/main/java/com/example/backend/lecture/entity/OneDayLecture.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 import java.time.Instant;
+import java.time.LocalDate;
 
 @Entity
 @DiscriminatorValue("OneDay")
@@ -18,6 +19,6 @@ import java.time.Instant;
 @AllArgsConstructor
 public class OneDayLecture extends Lecture{
 
-    @NotNull(message = "날짜가 비어있습니다.")
-    private Instant dateTime;
+    @NotNull
+    private LocalDate date;
 }

--- a/src/main/java/com/example/backend/lecture/entity/RegularLecture.java
+++ b/src/main/java/com/example/backend/lecture/entity/RegularLecture.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 import java.time.DayOfWeek;
 import java.time.Instant;
@@ -13,6 +14,7 @@ import java.util.Set;
 
 @Entity
 @DiscriminatorValue("Regular")
+@SuperBuilder(toBuilder = true)
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/example/backend/lecture/entity/RegularLecture.java
+++ b/src/main/java/com/example/backend/lecture/entity/RegularLecture.java
@@ -1,0 +1,33 @@
+package com.example.backend.lecture.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.DayOfWeek;
+import java.time.Instant;
+import java.time.LocalTime;
+import java.util.Set;
+
+@Entity
+@DiscriminatorValue("Regular")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RegularLecture extends Lecture{
+
+    @NotNull(message = "시작 날짜가 비어있습니다.")
+    private Instant startDate;
+
+    @NotNull(message = "종료 날짜가 비어있습니다.")
+    private Instant endDate;
+
+    @NotNull(message = "강의 시간이 비어있습니다.")
+    private LocalTime time;
+
+    @ElementCollection
+    @Enumerated(EnumType.STRING)
+    private Set<DayOfWeek> daysOfWeek;
+}

--- a/src/main/java/com/example/backend/lecture/entity/RegularLecture.java
+++ b/src/main/java/com/example/backend/lecture/entity/RegularLecture.java
@@ -9,6 +9,7 @@ import lombok.experimental.SuperBuilder;
 
 import java.time.DayOfWeek;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.Set;
 
@@ -20,14 +21,11 @@ import java.util.Set;
 @AllArgsConstructor
 public class RegularLecture extends Lecture{
 
-    @NotNull(message = "시작 날짜가 비어있습니다.")
-    private Instant startDate;
+    @NotNull
+    private LocalDate startDate;
 
-    @NotNull(message = "종료 날짜가 비어있습니다.")
-    private Instant endDate;
-
-    @NotNull(message = "강의 시간이 비어있습니다.")
-    private LocalTime time;
+    @NotNull
+    private LocalDate endDate;
 
     @ElementCollection
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/example/backend/lecture/entity/dto/request/CreateLectureRequestDTO.java
+++ b/src/main/java/com/example/backend/lecture/entity/dto/request/CreateLectureRequestDTO.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.*;
 import lombok.*;
 
 import java.time.Instant;
+import java.time.LocalTime;
 
 @Getter
 @Setter
@@ -22,4 +23,10 @@ public class CreateLectureRequestDTO {
 
     @NotBlank(message = "강의 위치가 비어있습니다.")
     private String location;
+
+    @NotNull(message = "시작 시간이 비어있습니다.")
+    private LocalTime startTime;
+
+    @NotNull(message = "종료 시간이 비어있습니다.")
+    private LocalTime endTime;
 }

--- a/src/main/java/com/example/backend/lecture/entity/dto/request/CreateLectureRequestDTO.java
+++ b/src/main/java/com/example/backend/lecture/entity/dto/request/CreateLectureRequestDTO.java
@@ -17,14 +17,8 @@ public class CreateLectureRequestDTO {
     @NotNull(message = "가격이 비어있습니다.")
     private Long price;
 
-    @NotBlank(message = "강의 유형이 비어있습니다.")
-    private String type;
-
     @NotNull(message = "최대인원이 비어있습니다.")
     private int member_limit;
-
-    @NotNull(message = "강의 날짜가 비어있습니다.")
-    private Instant dateTime;
 
     @NotBlank(message = "강의 위치가 비어있습니다.")
     private String location;

--- a/src/main/java/com/example/backend/lecture/entity/dto/request/CreateOneDayLectureRequestDTO.java
+++ b/src/main/java/com/example/backend/lecture/entity/dto/request/CreateOneDayLectureRequestDTO.java
@@ -1,0 +1,16 @@
+package com.example.backend.lecture.entity.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class CreateOneDayLectureRequestDTO extends CreateLectureRequestDTO {
+    @NotNull(message = "강의 날짜가 비어있습니다.")
+    private Instant dateTime;
+}

--- a/src/main/java/com/example/backend/lecture/entity/dto/request/CreateOneDayLectureRequestDTO.java
+++ b/src/main/java/com/example/backend/lecture/entity/dto/request/CreateOneDayLectureRequestDTO.java
@@ -6,11 +6,12 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.Instant;
+import java.time.LocalDate;
 
 @Getter
 @Setter
 @NoArgsConstructor
 public class CreateOneDayLectureRequestDTO extends CreateLectureRequestDTO {
     @NotNull(message = "강의 날짜가 비어있습니다.")
-    private Instant dateTime;
+    private LocalDate date;
 }

--- a/src/main/java/com/example/backend/lecture/entity/dto/request/CreateRegularLectureRequestDTO.java
+++ b/src/main/java/com/example/backend/lecture/entity/dto/request/CreateRegularLectureRequestDTO.java
@@ -8,6 +8,7 @@ import lombok.Setter;
 
 import java.time.DayOfWeek;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.Set;
 
@@ -15,14 +16,12 @@ import java.util.Set;
 @Setter
 @NoArgsConstructor
 public class CreateRegularLectureRequestDTO extends CreateLectureRequestDTO {
+
     @NotNull(message = "시작 날짜가 비어있습니다.")
-    private Instant startDate;
+    private LocalDate startDate;
 
     @NotNull(message = "종료 날짜가 비어있습니다.")
-    private Instant endDate;
-
-    @NotNull(message = "강의 시간이 비어있습니다.")
-    private LocalTime time;
+    private LocalDate endDate;
 
     @NotEmpty(message = "강의 요일이 비어있습니다.")
     private Set<DayOfWeek> daysOfWeek;

--- a/src/main/java/com/example/backend/lecture/entity/dto/request/CreateRegularLectureRequestDTO.java
+++ b/src/main/java/com/example/backend/lecture/entity/dto/request/CreateRegularLectureRequestDTO.java
@@ -1,0 +1,29 @@
+package com.example.backend.lecture.entity.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.DayOfWeek;
+import java.time.Instant;
+import java.time.LocalTime;
+import java.util.Set;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class CreateRegularLectureRequestDTO extends CreateLectureRequestDTO {
+    @NotNull(message = "시작 날짜가 비어있습니다.")
+    private Instant startDate;
+
+    @NotNull(message = "종료 날짜가 비어있습니다.")
+    private Instant endDate;
+
+    @NotNull(message = "강의 시간이 비어있습니다.")
+    private LocalTime time;
+
+    @NotEmpty(message = "강의 요일이 비어있습니다.")
+    private Set<DayOfWeek> daysOfWeek;
+}

--- a/src/main/java/com/example/backend/lecture/entity/dto/response/LectureDetailResponseDTO.java
+++ b/src/main/java/com/example/backend/lecture/entity/dto/response/LectureDetailResponseDTO.java
@@ -3,7 +3,10 @@ package com.example.backend.lecture.entity.dto.response;
 import jakarta.validation.constraints.*;
 import lombok.*;
 
+import java.time.DayOfWeek;
 import java.time.Instant;
+import java.time.LocalTime;
+import java.util.Set;
 
 @Getter
 @Setter
@@ -27,8 +30,15 @@ public class LectureDetailResponseDTO {
     @NotNull(message = "최대인원이 비어있습니다.")
     private int member_limit;
 
-    @NotNull(message = "강의 날짜가 비어있습니다.")
     private Instant dateTime;
+
+    private Instant startDate;
+
+    private Instant endDate;
+
+    private LocalTime time;
+
+    private Set<DayOfWeek> daysOfWeek;
 
     @NotBlank(message = "강의 위치가 비어있습니다.")
     private String location;

--- a/src/main/java/com/example/backend/lecture/entity/dto/response/LectureDetailResponseDTO.java
+++ b/src/main/java/com/example/backend/lecture/entity/dto/response/LectureDetailResponseDTO.java
@@ -5,6 +5,7 @@ import lombok.*;
 
 import java.time.DayOfWeek;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.Set;
 
@@ -30,13 +31,17 @@ public class LectureDetailResponseDTO {
     @NotNull(message = "최대인원이 비어있습니다.")
     private int member_limit;
 
-    private Instant dateTime;
+    @NotNull(message = "시작 시간이 비어있습니다.")
+    private LocalTime startTime;
 
-    private Instant startDate;
+    @NotNull(message = "종료 시간이 비어있습니다.")
+    private LocalTime endTime;
 
-    private Instant endDate;
+    private LocalDate date;
 
-    private LocalTime time;
+    private LocalDate startDate;
+
+    private LocalDate endDate;
 
     private Set<DayOfWeek> daysOfWeek;
 

--- a/src/main/java/com/example/backend/lecture/entity/dto/response/LectureListResponseDTO.java
+++ b/src/main/java/com/example/backend/lecture/entity/dto/response/LectureListResponseDTO.java
@@ -21,11 +21,11 @@ public class LectureListResponseDTO {
     @NotBlank(message = "강의명이 비어있습니다.")
     private String name;
 
-    @NotNull(message = "강의 날짜가 비어있습니다.")
-    private Instant dateTime;
-
     @NotBlank(message = "강의유형이 비어있습니다.")
     private String type;
+
+    @NotNull(message = "강의 가격이 비어있습니다.")
+    private Long price;
 
     @NotBlank(message = "이미지 주소가 비어있습니다.")
     private List<LectureImage> imageUrl;

--- a/src/main/java/com/example/backend/lecture/service/LectureService.java
+++ b/src/main/java/com/example/backend/lecture/service/LectureService.java
@@ -4,7 +4,11 @@ import com.example.backend.image.service.ImageService;
 import com.example.backend.lecture.entity.Lecture;
 import com.example.backend.lecture.entity.LectureImage;
 import com.example.backend.lecture.converter.LectureConverter;
+import com.example.backend.lecture.entity.OneDayLecture;
+import com.example.backend.lecture.entity.RegularLecture;
 import com.example.backend.lecture.entity.dto.request.CreateLectureRequestDTO;
+import com.example.backend.lecture.entity.dto.request.CreateOneDayLectureRequestDTO;
+import com.example.backend.lecture.entity.dto.request.CreateRegularLectureRequestDTO;
 import com.example.backend.lecture.entity.dto.response.LectureDetailResponseDTO;
 import com.example.backend.lecture.entity.dto.response.LectureListResponseDTO;
 import com.example.backend.lecture.repository.LectureRepository;
@@ -37,21 +41,41 @@ public class LectureService {
 
     private static final Logger logger = LoggerFactory.getLogger(LectureService.class);
 
-    // 강의 생성
+    // 원데이 강의 생성
     @Transactional
-    public LectureDetailResponseDTO createLecture(CreateLectureRequestDTO req, String email,
-                                                  List<MultipartFile> images){
+    public LectureDetailResponseDTO createOneDayLecture(CreateOneDayLectureRequestDTO req, String email,
+                                                        List<MultipartFile> images) {
         Member member = memberRepository.findByEmail(email).orElse(null);
         if(member == null){ // 없는 사용자라면 X
             logger.warn("사용자 찾을 수 없음");
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "사용자 찾을 수 없음");
         }
+        OneDayLecture oneDayLecture = LectureConverter.createOneDayLectureConverter(req);
+        return createLectureCommon(oneDayLecture, member, images);
+    }
+
+    // 정규 강의 생성
+    @Transactional
+    public LectureDetailResponseDTO createRegularLecture(CreateRegularLectureRequestDTO req, String email,
+                                                         List<MultipartFile> images) {
+        Member member = memberRepository.findByEmail(email).orElse(null);
+        if(member == null){ // 없는 사용자라면 X
+            logger.warn("사용자 찾을 수 없음");
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "사용자 찾을 수 없음");
+        }
+        RegularLecture regularLecture = LectureConverter.createRegularLectureConverter(req);
+        return createLectureCommon(regularLecture, member, images);
+    }
+
+    // 강의 생성 베이스
+    @Transactional
+    public LectureDetailResponseDTO createLectureCommon(Lecture lecture, Member member,
+                                                  List<MultipartFile> images){
         // 해당 부분은 개최자 인증 전엔 일단 주석
         /*if (member.getPermission().equals("USER")){ // 일반 유저라면 X
             logger.warn("접근 권한 없음");
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "접근 권한 없음");
         }*/
-        Lecture lecture = LectureConverter.createLectureConverter(req);
 
         imageService.procesAndAddImages(lecture, images,
                 url -> {

--- a/src/main/java/com/example/backend/member/entity/dto/request/SignupRequestDTO.java
+++ b/src/main/java/com/example/backend/member/entity/dto/request/SignupRequestDTO.java
@@ -17,4 +17,7 @@ public class SignupRequestDTO { // 회원가입 요청
 
     @NotBlank(message = "비밀번호 재입력이 비어있습니다.")
     private String checkPassword;
+
+    @NotBlank(message = "인증코드가 비어있습니다.")
+    private String verification;
 }

--- a/src/main/java/com/example/backend/member/service/MemberService.java
+++ b/src/main/java/com/example/backend/member/service/MemberService.java
@@ -51,15 +51,19 @@ public class MemberService {
             logger.warn("유효하지 않은 인증코드");
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "유효하지 않은 인증코드");
         }
-        if (checkEmailDuplication(req.getEmail())){
-            logger.warn("이메일 중복");
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "이메일 중복");
-        }
     }
 
     // 회원가입
     @Transactional
     public void signupMember(SignupRequestDTO req){
+        if (checkEmailDuplication(req.getEmail())){
+            logger.warn("이메일 중복");
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "이메일 중복");
+        }
+        if(!emailVerifyService.verifyCode(req.getEmail(), req.getVerification())){
+            logger.warn("유효하지 않은 인증코드");
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "유효하지 않은 인증코드");
+        }
         if (!req.getPassword().equals(req.getCheckPassword())){
             logger.warn("비밀번호 일치하지 않음");
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "비밀번호 일치하지 않음");


### PR DESCRIPTION
## 연관된 이슈

#34

## 개발 또는 수정사항
- Lecture Entity 베이스로 한 OneDayLecture, RegularLecture Entity 작성
- Lecture Converter 수정
- Lecture Service에 두 종류의 생성 로직 작성
- Lecture Controller에 API 분류
- Detail DTO 및 생성 요청 DTO 수정

## 사진
1. 원데이 클래스 생성 요청
![image](https://github.com/user-attachments/assets/f785f270-d419-426e-b548-44402f998701)
2. 정규 클래스 생성 요청
![image](https://github.com/user-attachments/assets/db90ad03-1c69-473c-9439-b2a118b09e43)
3. 내 클래스 목록 확인
![image](https://github.com/user-attachments/assets/cea94aa0-1f72-4aba-a449-9ea1c1d93f1b)
4. DB 확인
![image](https://github.com/user-attachments/assets/2adc08a2-e4a6-4f60-a38b-776f01070750)
뒤에 start_date도 있음