### PR TITLE
[Fix] 내 정보 수정 이미지 버그 및 강의 이미지 수정

### DIFF
--- a/src/main/java/com/example/backend/lecture/controller/LectureController.java
+++ b/src/main/java/com/example/backend/lecture/controller/LectureController.java
@@ -24,7 +24,7 @@ public class LectureController {
 
     @PostMapping(value = "/create/oneday", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<LectureDetailResponseDTO> createOneDayLecture(@RequestPart("lecture") @Valid CreateOneDayLectureRequestDTO req,
-                                                                  @RequestPart("images") List<MultipartFile> images,
+                                                                  @RequestPart(value = "images", required = false) List<MultipartFile> images,
                                                                   Authentication auth){
         String email = auth.getName();
         return ResponseEntity.ok(lectureService.createOneDayLecture(req, email, images));
@@ -32,7 +32,7 @@ public class LectureController {
 
     @PostMapping(value = "/create/regular", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<LectureDetailResponseDTO> createRegularLecture(@RequestPart("lecture") @Valid CreateRegularLectureRequestDTO req,
-                                                                  @RequestPart("images") List<MultipartFile> images,
+                                                                  @RequestPart(value = "images", required = false) List<MultipartFile> images,
                                                                   Authentication auth){
         String email = auth.getName();
         return ResponseEntity.ok(lectureService.createRegularLecture(req, email, images));

--- a/src/main/java/com/example/backend/lecture/converter/LectureConverter.java
+++ b/src/main/java/com/example/backend/lecture/converter/LectureConverter.java
@@ -64,6 +64,7 @@ public class LectureConverter {
             dto.setEndDate(regularLecture.getEndDate());
             dto.setDaysOfWeek(regularLecture.getDaysOfWeek());
         }
+        dto.setImageUrl(lecture.getLectureImages() != null ? lecture.getLectureImages() : null);
 
         return dto;
     }
@@ -74,7 +75,7 @@ public class LectureConverter {
         dto.setName(lecture.getName());
         dto.setType(lecture instanceof OneDayLecture ? "OneDay" : "Regular");
         dto.setPrice(lecture.getPrice());
-        dto.setImageUrl(lecture.getLectureImages());
+        dto.setImageUrl(lecture.getLectureImages() != null ? lecture.getLectureImages() : null);
         return dto;
     }
 }

--- a/src/main/java/com/example/backend/lecture/entity/dto/response/LectureDetailResponseDTO.java
+++ b/src/main/java/com/example/backend/lecture/entity/dto/response/LectureDetailResponseDTO.java
@@ -1,5 +1,6 @@
 package com.example.backend.lecture.entity.dto.response;
 
+import com.example.backend.lecture.entity.LectureImage;
 import jakarta.validation.constraints.*;
 import lombok.*;
 
@@ -7,6 +8,7 @@ import java.time.DayOfWeek;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 import java.util.Set;
 
 @Getter
@@ -55,4 +57,6 @@ public class LectureDetailResponseDTO {
     private String address;
 
     private String detailAddress;
+
+    private List<LectureImage> imageUrl;
 }

--- a/src/main/java/com/example/backend/lecture/entity/dto/response/LectureListResponseDTO.java
+++ b/src/main/java/com/example/backend/lecture/entity/dto/response/LectureListResponseDTO.java
@@ -27,6 +27,5 @@ public class LectureListResponseDTO {
     @NotNull(message = "강의 가격이 비어있습니다.")
     private Long price;
 
-    @NotBlank(message = "이미지 주소가 비어있습니다.")
     private List<LectureImage> imageUrl;
 }

--- a/src/main/java/com/example/backend/lecture/service/LectureService.java
+++ b/src/main/java/com/example/backend/lecture/service/LectureService.java
@@ -89,12 +89,14 @@ public class LectureService {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "접근 권한 없음");
         }*/
 
-        imageService.procesAndAddImages(lecture, images,
-                url -> {
-                    LectureImage image = new LectureImage();
-                    image.setImageUrl(url);
-                    return image;
-                }, Lecture::addImage);
+        if (images!=null && !images.isEmpty()){
+            imageService.procesAndAddImages(lecture, images,
+                    url -> {
+                        LectureImage image = new LectureImage();
+                        image.setImageUrl(url);
+                        return image;
+                    }, Lecture::addImage);
+        }
         Lecture saveLecture = lectureRepository.save(lecture);
         participantRepository.save(ParticipantConverter.createParticipantConverter(member, saveLecture));
         return LectureConverter.lectureDetailConverter(saveLecture);

--- a/src/main/java/com/example/backend/memberInfo/controller/MemberInfoController.java
+++ b/src/main/java/com/example/backend/memberInfo/controller/MemberInfoController.java
@@ -20,7 +20,7 @@ public class MemberInfoController {
 
     @PatchMapping(value = "/edit", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<MemberInfoDetailResponseDTO> editInfo(@RequestPart("info") @Valid EditMemberInfoRequestDTO req,
-                                                                @RequestPart("images") MultipartFile image,
+                                                                @RequestPart(value = "images", required = false) MultipartFile image,
                                                                 Authentication auth){
         String email = auth.getName();
         return ResponseEntity.ok(memberInfoService.editMemberInfo(req, email ,image));

--- a/src/main/java/com/example/backend/memberInfo/entity/dto/request/EditMemberInfoRequestDTO.java
+++ b/src/main/java/com/example/backend/memberInfo/entity/dto/request/EditMemberInfoRequestDTO.java
@@ -11,7 +11,6 @@ import lombok.Setter;
 @NoArgsConstructor
 public class EditMemberInfoRequestDTO {
 
-    @NotBlank(message = "닉네임이 비어있습니다.")
     private String nickname;
 
     private String introduction;


### PR DESCRIPTION
## 연관된 이슈

#42

## 개발 또는 수정사항
- LectureList DTO 수정
- Image 요청 required = false 설정
- LectureDetail DTO에 이미지 추가

## 사진
1. 이미지 없이 수정 요청
![image](https://github.com/user-attachments/assets/9dfbee90-4b0c-4977-bccf-268866183c27)
2. 이미지 없이 강의 생성
![image](https://github.com/user-attachments/assets/ce5bb5a8-880f-4dfe-994a-00da227bc43e)
3. 이미지 없는 강의 조회
![image](https://github.com/user-attachments/assets/7a88ff17-2006-498a-adb7-8e6512dc66b7)
