### PR TITLE
[FEATURE] 강의 검색, 내 강의 조회 분리, 배너 강의, 강의 상세 개발

### DIFF
--- a/src/main/java/com/example/backend/lecture/controller/LectureController.java
+++ b/src/main/java/com/example/backend/lecture/controller/LectureController.java
@@ -55,7 +55,12 @@ public class LectureController {
     }
 
     @GetMapping("/search")
-    public ResponseEntity<List<LectureListResponseDTO>> searchLectureByKeyword(@RequestParam(value = "keyword") String keyword){
+    public ResponseEntity<List<LectureListResponseDTO>> searchLectureByKeyword(@RequestParam("keyword") String keyword){
         return ResponseEntity.ok(lectureService.searchLectureByKeyword(keyword));
+    }
+
+    @GetMapping("/{lecture}")
+    public ResponseEntity<LectureDetailResponseDTO> lectureDetail(@PathVariable("lecture") Long lecture_id){
+        return ResponseEntity.ok(lectureService.lectureDetail(lecture_id));
     }
 }

--- a/src/main/java/com/example/backend/lecture/controller/LectureController.java
+++ b/src/main/java/com/example/backend/lecture/controller/LectureController.java
@@ -53,4 +53,9 @@ public class LectureController {
     public ResponseEntity<List<LectureListResponseDTO>> getLectureByCategory(@RequestParam(defaultValue = "ALL", value = "category") String category){
         return ResponseEntity.ok(lectureService.getLectureByCategory(category));
     }
+
+    @GetMapping("/search")
+    public ResponseEntity<List<LectureListResponseDTO>> searchLectureByKeyword(@RequestParam(value = "keyword") String keyword){
+        return ResponseEntity.ok(lectureService.searchLectureByKeyword(keyword));
+    }
 }

--- a/src/main/java/com/example/backend/lecture/controller/LectureController.java
+++ b/src/main/java/com/example/backend/lecture/controller/LectureController.java
@@ -4,6 +4,7 @@ import com.example.backend.category.Category;
 import com.example.backend.lecture.entity.dto.request.CreateLectureRequestDTO;
 import com.example.backend.lecture.entity.dto.request.CreateOneDayLectureRequestDTO;
 import com.example.backend.lecture.entity.dto.request.CreateRegularLectureRequestDTO;
+import com.example.backend.lecture.entity.dto.response.LectureBannerResponseDTO;
 import com.example.backend.lecture.entity.dto.response.LectureDetailResponseDTO;
 import com.example.backend.lecture.entity.dto.response.LectureListResponseDTO;
 import com.example.backend.lecture.service.LectureService;
@@ -62,5 +63,10 @@ public class LectureController {
     @GetMapping("/{lecture}")
     public ResponseEntity<LectureDetailResponseDTO> lectureDetail(@PathVariable("lecture") Long lecture_id){
         return ResponseEntity.ok(lectureService.lectureDetail(lecture_id));
+    }
+
+    @GetMapping("/banner")
+    private ResponseEntity<List<LectureBannerResponseDTO>> lectureBanner(){
+        return ResponseEntity.ok(lectureService.lectureBanner());
     }
 }

--- a/src/main/java/com/example/backend/lecture/controller/LectureController.java
+++ b/src/main/java/com/example/backend/lecture/controller/LectureController.java
@@ -40,8 +40,8 @@ public class LectureController {
     }
 
     @GetMapping("/own")
-    public ResponseEntity<List<LectureListResponseDTO>> getMyLecture(Authentication auth){
-        return ResponseEntity.ok(lectureService.getMyLecture(auth.getName()));
+    public ResponseEntity<List<LectureListResponseDTO>> getMyLecture(Authentication auth, @RequestParam("permission") String permission){
+        return ResponseEntity.ok(lectureService.getMyLecture(auth.getName(), permission));
     }
 
     @PostMapping("/join")

--- a/src/main/java/com/example/backend/lecture/converter/LectureConverter.java
+++ b/src/main/java/com/example/backend/lecture/converter/LectureConverter.java
@@ -80,4 +80,7 @@ public class LectureConverter {
         dto.setPrice(lecture.getPrice());
         dto.setSearchCount(lecture.getLectureCount() != null ? lecture.getLectureCount().getViewCount() : 0);
         dto.setImageUrl(lecture.getLectureImages() != null ? lecture.getLectureImages() : null);
+        if (lecture)
         return dto;
+    }
+}

--- a/src/main/java/com/example/backend/lecture/converter/LectureConverter.java
+++ b/src/main/java/com/example/backend/lecture/converter/LectureConverter.java
@@ -7,6 +7,7 @@ import com.example.backend.lecture.entity.dto.request.CreateOneDayLectureRequest
 import com.example.backend.lecture.entity.dto.request.CreateRegularLectureRequestDTO;
 import com.example.backend.lecture.entity.dto.response.LectureDetailResponseDTO;
 import com.example.backend.lecture.entity.dto.response.LectureListResponseDTO;
+import com.example.backend.review.entity.Review;
 
 public class LectureConverter {
 
@@ -80,7 +81,14 @@ public class LectureConverter {
         dto.setPrice(lecture.getPrice());
         dto.setSearchCount(lecture.getLectureCount() != null ? lecture.getLectureCount().getViewCount() : 0);
         dto.setImageUrl(lecture.getLectureImages() != null ? lecture.getLectureImages() : null);
-        if (lecture)
+        if (lecture.getReviews() != null && lecture.getReviews().size() >= 5) {
+            dto.setAverageScore(lecture.getReviews().stream()
+                    .mapToLong(Review::getScore)
+                    .average()
+                    .orElse(0));
+        }else {
+            dto.setAverageScore(0);
+        }
         return dto;
     }
 }

--- a/src/main/java/com/example/backend/lecture/converter/LectureConverter.java
+++ b/src/main/java/com/example/backend/lecture/converter/LectureConverter.java
@@ -68,6 +68,14 @@ public class LectureConverter {
             dto.setEndDate(regularLecture.getEndDate());
             dto.setDaysOfWeek(regularLecture.getDaysOfWeek());
         }
+        if (lecture.getReviews() != null && lecture.getReviews().size() >= 5) {
+            dto.setAverageScore(lecture.getReviews().stream()
+                    .mapToLong(Review::getScore)
+                    .average()
+                    .orElse(0));
+        }else {
+            dto.setAverageScore(0);
+        }
         dto.setImageUrl(lecture.getLectureImages() != null ? lecture.getLectureImages() : null);
 
         return dto;
@@ -81,7 +89,7 @@ public class LectureConverter {
         dto.setPrice(lecture.getPrice());
         dto.setSearchCount(lecture.getLectureCount() != null ? lecture.getLectureCount().getViewCount() : 0);
         dto.setImageUrl(lecture.getLectureImages() != null ? lecture.getLectureImages() : null);
-        if (lecture.getReviews() != null && lecture.getReviews().size() >= 5) {
+        if (lecture.getReviews() != null ) {
             dto.setAverageScore(lecture.getReviews().stream()
                     .mapToLong(Review::getScore)
                     .average()

--- a/src/main/java/com/example/backend/lecture/converter/LectureConverter.java
+++ b/src/main/java/com/example/backend/lecture/converter/LectureConverter.java
@@ -78,7 +78,6 @@ public class LectureConverter {
         dto.setName(lecture.getName());
         dto.setType(lecture instanceof OneDayLecture ? "OneDay" : "Regular");
         dto.setPrice(lecture.getPrice());
+        dto.setSearchCount(lecture.getLectureCount() != null ? lecture.getLectureCount().getViewCount() : 0);
         dto.setImageUrl(lecture.getLectureImages() != null ? lecture.getLectureImages() : null);
         return dto;
-    }
-}

--- a/src/main/java/com/example/backend/lecture/converter/LectureConverter.java
+++ b/src/main/java/com/example/backend/lecture/converter/LectureConverter.java
@@ -5,6 +5,7 @@ import com.example.backend.lecture.entity.OneDayLecture;
 import com.example.backend.lecture.entity.RegularLecture;
 import com.example.backend.lecture.entity.dto.request.CreateOneDayLectureRequestDTO;
 import com.example.backend.lecture.entity.dto.request.CreateRegularLectureRequestDTO;
+import com.example.backend.lecture.entity.dto.response.LectureBannerResponseDTO;
 import com.example.backend.lecture.entity.dto.response.LectureDetailResponseDTO;
 import com.example.backend.lecture.entity.dto.response.LectureListResponseDTO;
 import com.example.backend.review.entity.Review;
@@ -99,6 +100,14 @@ public class LectureConverter {
             dto.setAverageScore(0);
             dto.setScoreCount(0);
         }
+        return dto;
+    }
+
+    public static LectureBannerResponseDTO lectureBannerConverter(Lecture lecture){
+        LectureBannerResponseDTO dto = new LectureBannerResponseDTO();
+        dto.setId(lecture.getId());
+        dto.setName(lecture.getName());
+        dto.setImageUrl(lecture.getLectureImages() != null ? lecture.getLectureImages().get(0).getImageUrl() : null);
         return dto;
     }
 }

--- a/src/main/java/com/example/backend/lecture/converter/LectureConverter.java
+++ b/src/main/java/com/example/backend/lecture/converter/LectureConverter.java
@@ -94,8 +94,10 @@ public class LectureConverter {
                     .mapToLong(Review::getScore)
                     .average()
                     .orElse(0));
+            dto.setScoreCount(lecture.getReviews().size());
         }else {
             dto.setAverageScore(0);
+            dto.setScoreCount(0);
         }
         return dto;
     }

--- a/src/main/java/com/example/backend/lecture/entity/Lecture.java
+++ b/src/main/java/com/example/backend/lecture/entity/Lecture.java
@@ -2,6 +2,7 @@ package com.example.backend.lecture.entity;
 
 import com.example.backend.participant.entity.Participant;
 import com.example.backend.category.Category;
+import com.example.backend.review.entity.Review;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
@@ -74,6 +75,10 @@ public class Lecture {
     @JsonManagedReference
     @OneToMany(mappedBy = "lecture", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<LectureImage> lectureImages;
+
+    @JsonManagedReference
+    @OneToMany(mappedBy = "lecture", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Review> reviews;
 
     public void addImage(LectureImage image) {
         if (lectureImages == null) {

--- a/src/main/java/com/example/backend/lecture/entity/Lecture.java
+++ b/src/main/java/com/example/backend/lecture/entity/Lecture.java
@@ -64,6 +64,10 @@ public class Lecture {
     private Category category;
 
     @JsonManagedReference
+    @OneToOne(mappedBy = "lecture", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private LectureCount lectureCount;
+
+    @JsonManagedReference
     @OneToMany(mappedBy = "lecture", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<Participant> participants;
 

--- a/src/main/java/com/example/backend/lecture/entity/LectureCount.java
+++ b/src/main/java/com/example/backend/lecture/entity/LectureCount.java
@@ -1,0 +1,30 @@
+package com.example.backend.lecture.entity;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "LectureCount")
+@Builder(toBuilder = true)
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
+public class LectureCount {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @JsonBackReference
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "lecture_id")
+    private Lecture lecture;
+
+    private Long viewCount = 0L;
+}

--- a/src/main/java/com/example/backend/lecture/entity/LectureCount.java
+++ b/src/main/java/com/example/backend/lecture/entity/LectureCount.java
@@ -27,4 +27,8 @@ public class LectureCount {
     private Lecture lecture;
 
     private Long viewCount = 0L;
+
+    public void incrementViewCount() {
+        this.viewCount++;
+    }
 }

--- a/src/main/java/com/example/backend/lecture/entity/LectureCount.java
+++ b/src/main/java/com/example/backend/lecture/entity/LectureCount.java
@@ -26,9 +26,10 @@ public class LectureCount {
     @JoinColumn(name = "lecture_id")
     private Lecture lecture;
 
-    private Long viewCount = 0L;
+    private Long viewCount;
 
-    public void incrementViewCount() {
-        this.viewCount++;
-    }
+    // Optimistic Locking을 위한 속성
+    // 동시성 제어
+    @Version
+    private Long version;
 }

--- a/src/main/java/com/example/backend/lecture/entity/dto/response/LectureBannerResponseDTO.java
+++ b/src/main/java/com/example/backend/lecture/entity/dto/response/LectureBannerResponseDTO.java
@@ -2,7 +2,13 @@ package com.example.backend.lecture.entity.dto.response;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@NoArgsConstructor
 public class LectureBannerResponseDTO {
     @NotNull(message = "강의 ID가 비어있습니다.")
     private Long id;

--- a/src/main/java/com/example/backend/lecture/entity/dto/response/LectureBannerResponseDTO.java
+++ b/src/main/java/com/example/backend/lecture/entity/dto/response/LectureBannerResponseDTO.java
@@ -1,0 +1,14 @@
+package com.example.backend.lecture.entity.dto.response;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public class LectureBannerResponseDTO {
+    @NotNull(message = "강의 ID가 비어있습니다.")
+    private Long id;
+
+    @NotBlank(message = "강의명이 비어있습니다.")
+    private String name;
+
+    private String imageUrl;
+}

--- a/src/main/java/com/example/backend/lecture/entity/dto/response/LectureDetailResponseDTO.java
+++ b/src/main/java/com/example/backend/lecture/entity/dto/response/LectureDetailResponseDTO.java
@@ -62,5 +62,7 @@ public class LectureDetailResponseDTO {
     @NotBlank(message = "카테고리가 비어있습니다.")
     private Category category;
 
+    private double averageScore;
+
     private List<LectureImage> imageUrl;
 }

--- a/src/main/java/com/example/backend/lecture/entity/dto/response/LectureListResponseDTO.java
+++ b/src/main/java/com/example/backend/lecture/entity/dto/response/LectureListResponseDTO.java
@@ -29,5 +29,7 @@ public class LectureListResponseDTO {
 
     private Long searchCount;
 
+    private double averageScore;
+
     private List<LectureImage> imageUrl;
 }

--- a/src/main/java/com/example/backend/lecture/entity/dto/response/LectureListResponseDTO.java
+++ b/src/main/java/com/example/backend/lecture/entity/dto/response/LectureListResponseDTO.java
@@ -27,5 +27,7 @@ public class LectureListResponseDTO {
     @NotNull(message = "강의 가격이 비어있습니다.")
     private Long price;
 
+    private Long searchCount;
+
     private List<LectureImage> imageUrl;
 }

--- a/src/main/java/com/example/backend/lecture/entity/dto/response/LectureListResponseDTO.java
+++ b/src/main/java/com/example/backend/lecture/entity/dto/response/LectureListResponseDTO.java
@@ -31,5 +31,7 @@ public class LectureListResponseDTO {
 
     private double averageScore;
 
+    private int scoreCount;
+
     private List<LectureImage> imageUrl;
 }

--- a/src/main/java/com/example/backend/lecture/repository/LectureRepository.java
+++ b/src/main/java/com/example/backend/lecture/repository/LectureRepository.java
@@ -2,6 +2,7 @@ package com.example.backend.lecture.repository;
 
 import com.example.backend.category.Category;
 import com.example.backend.lecture.entity.Lecture;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -20,4 +21,8 @@ public interface LectureRepository extends JpaRepository<Lecture, Long> {
     @Modifying(clearAutomatically = true)
     @Query("UPDATE LectureCount lc SET lc.viewCount = lc.viewCount + 1 WHERE lc.lecture.id = :lectureId")
     void incrementViewCount(@Param("lectureId") Long lectureId);
+
+    // 범위만큼 검색이 가장 많이 된 강의 조회
+    @Query("SELECT l FROM Lecture l JOIN l.lectureCount lc ORDER BY lc.viewCount DESC")
+    List<Lecture> findTop5ByOrderByViewCountDesc(Pageable pageable);
 }

--- a/src/main/java/com/example/backend/lecture/repository/LectureRepository.java
+++ b/src/main/java/com/example/backend/lecture/repository/LectureRepository.java
@@ -3,10 +3,21 @@ package com.example.backend.lecture.repository;
 import com.example.backend.category.Category;
 import com.example.backend.lecture.entity.Lecture;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface LectureRepository extends JpaRepository<Lecture, Long> {
     List<Lecture> findByCategory(Category category);
-    List<Lecture> findByNameContainingOrDescriptionContaining(String name, String description);
+
+    // 대소문자 구별 없이 이름 또는 설명에 키워드가 포함된 강의 조회
+    @Query("SELECT l FROM Lecture l WHERE LOWER(l.name) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(l.description) LIKE LOWER(CONCAT('%', :keyword, '%'))")
+    List<Lecture> findByNameContainingOrDescriptionContaining(@Param("keyword") String keyword);
+
+    // 조회된 강의 조회 1증가
+    @Modifying
+    @Query("UPDATE LectureCount lc SET lc.viewCount = lc.viewCount + 1 WHERE lc.lecture.id = :lectureId")
+    void incrementViewCount(@Param("lectureId") Long lectureId);
 }

--- a/src/main/java/com/example/backend/lecture/repository/LectureRepository.java
+++ b/src/main/java/com/example/backend/lecture/repository/LectureRepository.java
@@ -24,5 +24,5 @@ public interface LectureRepository extends JpaRepository<Lecture, Long> {
 
     // 범위만큼 검색이 가장 많이 된 강의 조회
     @Query("SELECT l FROM Lecture l JOIN l.lectureCount lc ORDER BY lc.viewCount DESC")
-    List<Lecture> findTop5ByOrderByViewCountDesc(Pageable pageable);
+    List<Lecture> findTop3ByOrderByViewCountDesc(Pageable pageable);
 }

--- a/src/main/java/com/example/backend/lecture/repository/LectureRepository.java
+++ b/src/main/java/com/example/backend/lecture/repository/LectureRepository.java
@@ -17,7 +17,7 @@ public interface LectureRepository extends JpaRepository<Lecture, Long> {
     List<Lecture> findByNameContainingOrDescriptionContaining(@Param("keyword") String keyword);
 
     // 조회된 강의 조회 1증가
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("UPDATE LectureCount lc SET lc.viewCount = lc.viewCount + 1 WHERE lc.lecture.id = :lectureId")
     void incrementViewCount(@Param("lectureId") Long lectureId);
 }

--- a/src/main/java/com/example/backend/lecture/repository/LectureRepository.java
+++ b/src/main/java/com/example/backend/lecture/repository/LectureRepository.java
@@ -8,4 +8,5 @@ import java.util.List;
 
 public interface LectureRepository extends JpaRepository<Lecture, Long> {
     List<Lecture> findByCategory(Category category);
+    List<Lecture> findByNameContainingOrDescriptionContaining(String name, String description);
 }

--- a/src/main/java/com/example/backend/lecture/service/LectureService.java
+++ b/src/main/java/com/example/backend/lecture/service/LectureService.java
@@ -100,6 +100,16 @@ public class LectureService {
         return LectureConverter.lectureDetailConverter(saveLecture);
     }
 
+    // 강의 상세 조회
+    public LectureDetailResponseDTO lectureDetail(Long lecture_id){
+        Lecture lecture = lectureRepository.findById(lecture_id).orElse(null);
+        if(lecture == null){
+            logger.warn("강의 찾을 수 없음");
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "강의 찾을 수 없음");
+        }
+        return LectureConverter.lectureDetailConverter(lecture);
+    }
+
     // 카테고리로 강의 조회
     public List<LectureListResponseDTO> getLectureByCategory(String categoryName){
         Category category;

--- a/src/main/java/com/example/backend/lecture/service/LectureService.java
+++ b/src/main/java/com/example/backend/lecture/service/LectureService.java
@@ -135,6 +135,17 @@ public class LectureService {
                 .collect(Collectors.toList());
     }
 
+    // 텍스트로 강의 조회
+    public List<LectureListResponseDTO> searchLectureByKeyword(String keyword){
+        List<Lecture> findLectures = lectureRepository.findByNameContainingOrDescriptionContaining(keyword);
+        for (Lecture lecture : findLectures){
+            lectureRepository.incrementViewCount(lecture.getId());
+        }
+        return findLectures.stream()
+                .map(LectureConverter::lectureListConverter)
+                .collect(Collectors.toList());
+    }
+
     // 강의 참가
     @Transactional
     public LectureDetailResponseDTO joinLecture(Long lectureId, String email){

--- a/src/main/java/com/example/backend/lecture/service/LectureService.java
+++ b/src/main/java/com/example/backend/lecture/service/LectureService.java
@@ -7,6 +7,7 @@ import com.example.backend.lecture.converter.LectureConverter;
 import com.example.backend.lecture.entity.dto.request.CreateLectureRequestDTO;
 import com.example.backend.lecture.entity.dto.request.CreateOneDayLectureRequestDTO;
 import com.example.backend.lecture.entity.dto.request.CreateRegularLectureRequestDTO;
+import com.example.backend.lecture.entity.dto.response.LectureBannerResponseDTO;
 import com.example.backend.lecture.entity.dto.response.LectureDetailResponseDTO;
 import com.example.backend.lecture.entity.dto.response.LectureListResponseDTO;
 import com.example.backend.lecture.repository.LectureRepository;
@@ -21,6 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Primary;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -108,6 +110,15 @@ public class LectureService {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "강의 찾을 수 없음");
         }
         return LectureConverter.lectureDetailConverter(lecture);
+    }
+
+    // 배너 강의 조회
+    public List<LectureBannerResponseDTO> lectureBanner(){
+        PageRequest topThree = PageRequest.of(0, 3);
+        List<Lecture> lectures = lectureRepository.findTop3ByOrderByViewCountDesc(topThree);
+        return lectures.stream()
+                .map(LectureConverter::lectureBannerConverter)
+                .collect(Collectors.toList());
     }
 
     // 카테고리로 강의 조회

--- a/src/main/java/com/example/backend/lecture/service/LectureService.java
+++ b/src/main/java/com/example/backend/lecture/service/LectureService.java
@@ -121,13 +121,13 @@ public class LectureService {
     }
 
     // 내가 참가한 강의 조회
-    public List<LectureListResponseDTO> getMyLecture(String email){
+    public List<LectureListResponseDTO> getMyLecture(String email, String permission){
         Member member = memberRepository.findByEmail(email).orElse(null);
         if(member == null){
             logger.warn("사용자 찾을 수 없음");
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "사용자 찾을 수 없음");
         }
-        return participantRepository.findLecturesByMemberId(member.getId()).stream()
+        return participantRepository.findLecturesByMemberIdAndRole(member.getId(), permission.toUpperCase()).stream()
                 .map(LectureConverter::lectureListConverter)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/example/backend/participant/repository/ParticipantRepository.java
+++ b/src/main/java/com/example/backend/participant/repository/ParticipantRepository.java
@@ -3,6 +3,7 @@ package com.example.backend.participant.repository;
 import com.example.backend.lecture.entity.Lecture;
 import com.example.backend.member.entity.Member;
 import com.example.backend.participant.entity.Participant;
+import jakarta.validation.constraints.NotBlank;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,6 +14,6 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
     long countByLecture(Lecture lecture);
     boolean existsByLectureAndMember(Lecture lecture, Member member);
 
-    @Query("SELECT DISTINCT p.lecture FROM Participant p WHERE p.member.id = :memberId")
-    List<Lecture> findLecturesByMemberId(@Param("memberId") Long memberId);
+    @Query("SELECT p.lecture FROM Participant p WHERE p.member.id = :member_id AND p.role = :role")
+    List<Lecture> findLecturesByMemberIdAndRole(@Param("member_id") Long member_id, @Param("role") String role);
 }


### PR DESCRIPTION
## 연관된 이슈

#46

## 개발 또는 수정사항
- Lecture Controller, Service, Repository 수정
- DTO에 강의 검색 횟수와 평점 추가  

## 사진
1. 키워드로 강의 검색해보기 ( 제목이나 설명에 포함된 강의만 조회됨 )
![image](https://github.com/user-attachments/assets/29ab6ba9-792f-437e-9cf4-ddc1d1353c48)
![image](https://github.com/user-attachments/assets/d06b2c38-7379-4c70-a938-373aac87a6e9)
2. 내 강의 조회 권한 분리 ( 참가한 강의 없이 개최만 한 상태 )
![image](https://github.com/user-attachments/assets/5815695e-d108-440f-bbe7-1226797b126e)
3. 가장 있기있는 강의 3개 조회해서 배너로 보냄
![image](https://github.com/user-attachments/assets/730fc74d-97cc-47d2-900a-c50201069f2b)
4. 강의 상세 보기
![image](https://github.com/user-attachments/assets/f55e376e-15a7-431d-8bc7-14196c6cfb0e)
![image](https://github.com/user-attachments/assets/d754dee2-d3d4-44a0-936f-d004e7013a03)
![image](https://github.com/user-attachments/assets/4ca5ace2-6ec3-4795-b81d-f1be7645af24)